### PR TITLE
Switch to apollo compiler latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,26 +282,24 @@ dependencies = [
 
 [[package]]
 name = "apollo-compiler"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2436eb22464134efc641e508b33229361b27a3d5b6f03242b66b170ab8786c"
+version = "1.0.0-beta.5"
+source = "git+https://github.com/apollographql/apollo-rs.git?tag=apollo-compiler@1.0.0-beta.5#26c2ad6b219d4c2c30d73bab21316d20c69ac0b9"
 dependencies = [
  "apollo-parser",
  "ariadne",
  "indexmap 2.0.2",
- "ordered-float",
  "rowan",
  "salsa",
  "serde",
  "thiserror",
+ "triomphe",
  "uuid",
 ]
 
 [[package]]
 name = "apollo-parser"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3cd0ce63c32c83e035757af12e3ae30566ce5d1ae183c02a2dd089a0df65aa"
+version = "0.7.3"
+source = "git+https://github.com/apollographql/apollo-rs.git?tag=apollo-compiler@1.0.0-beta.5#26c2ad6b219d4c2c30d73bab21316d20c69ac0b9"
 dependencies = [
  "memchr",
  "rowan",
@@ -1012,15 +1010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,15 +1029,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "ordered-float"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "536900a8093134cf9ccf00a27deb3532421099e958d9dd431135d0c7543ca1e8"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1418,6 +1398,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,6 +1563,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "triomphe"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee8098afad3fb0c54a9007aab6804558410503ad676d4633f9c2559a00ac0f"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "apollo-compiler"
 version = "1.0.0-beta.5"
-source = "git+https://github.com/apollographql/apollo-rs.git?tag=apollo-compiler@1.0.0-beta.5#26c2ad6b219d4c2c30d73bab21316d20c69ac0b9"
+source = "git+https://github.com/apollographql/apollo-rs.git?branch=main#6b0eb3eba026bcdd842f3d3f83f43374e0aee18a"
 dependencies = [
  "apollo-parser",
  "ariadne",
@@ -291,6 +291,7 @@ dependencies = [
  "rowan",
  "salsa",
  "serde",
+ "sptr",
  "thiserror",
  "triomphe",
  "uuid",
@@ -299,7 +300,7 @@ dependencies = [
 [[package]]
 name = "apollo-parser"
 version = "0.7.3"
-source = "git+https://github.com/apollographql/apollo-rs.git?tag=apollo-compiler@1.0.0-beta.5#26c2ad6b219d4c2c30d73bab21316d20c69ac0b9"
+source = "git+https://github.com/apollographql/apollo-rs.git?branch=main#6b0eb3eba026bcdd842f3d3f83f43374e0aee18a"
 dependencies = [
  "memchr",
  "rowan",
@@ -1396,6 +1397,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ exclude = ["./react_app/*"]
 
 [dependencies]
 actix-web = "4.4.0"
-apollo-compiler = "0.11.3"
+#apollo-compiler = "0.11.3"
+apollo-compiler = { git = "https://github.com/apollographql/apollo-rs.git", tag = "apollo-compiler@1.0.0-beta.5"}
 clap = { version = "4.4.3", features = ["derive"] }
 cruet = "0.13.3"
 dialoguer = "0.10.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["./react_app/*"]
 [dependencies]
 actix-web = "4.4.0"
 #apollo-compiler = "0.11.3"
-apollo-compiler = { git = "https://github.com/apollographql/apollo-rs.git", tag = "apollo-compiler@1.0.0-beta.5"}
+apollo-compiler = { git = "https://github.com/apollographql/apollo-rs.git", branch = "main" }
 clap = { version = "4.4.3", features = ["derive"] }
 cruet = "0.13.3"
 dialoguer = "0.10.4"

--- a/src/cli/server/model.rs
+++ b/src/cli/server/model.rs
@@ -289,7 +289,7 @@ fn parse_record(json: &str, model: &ModelDefinition) -> Result<Record> {
 }
 
 fn add_null_values(mut record: Record, model: &ModelDefinition) -> Record {
-    for (attr_name, _) in &model.attributes {
+    for attr_name in model.attributes.keys() {
         if !record.contains_key(attr_name) {
             record.insert(attr_name.clone(), NULL);
         }

--- a/src/cli/server/model/graphql.rs
+++ b/src/cli/server/model/graphql.rs
@@ -2,9 +2,7 @@
 use serde::ser;
 
 // used types
-use apollo_compiler::diagnostics::GraphQLError;
 use std::collections::HashMap;
-use std::sync::Arc;
 use super::{
     TruePrimitiveType,
     ModelDefinition,
@@ -20,21 +18,26 @@ use serde_derive::{
     Serialize
 };
 use apollo_compiler::{
-    ApolloDiagnostic as Diagnostic,
-    ApolloCompiler as Compiler,
-    HirDatabase,
-    FileId
+    // ApolloDiagnostic as Diagnostic,
+    // ApolloCompiler as Compiler,
+    ExecutableDocument,
+    GraphQLError,
+    // HirDatabase,
+    Schema,
+    // FileId,
+    Node
 };
-use apollo_compiler::hir::{
-    OperationDefinition as Operation,
-    FieldDefinition,
-    TypeDefinition,
-    OperationType,
-    SelectionSet,
-    Selection,
-    Field,
-    Value,
-    Type
+use apollo_compiler::executable::{
+    OperationRef,
+    Operation,
+    // FieldDefinition,
+    // TypeDefinition,
+    // OperationType,
+    // SelectionSet,
+    // Selection,
+    // Field,
+    // Value,
+    // Type
 };
 
 // used functions
@@ -261,304 +264,305 @@ fn to_gql_type(prim_type: &PrimitiveType) -> String {
 }
 
 pub fn handle_gql_post(body: GraphQLPost) -> GraphQLReturn {
-    let mut compiler = Compiler::new(); //.token_limit(...).recursion_limit(...) TODO!
-    compiler.add_type_system(&create_schema(), "schema");
-    let query_key: FileId = compiler.add_executable(&body.query, "query");
-    let validated: Vec<Diagnostic> = compiler.validate();
-    if !validated.is_empty() {
-        return GraphQLReturn::from(validated.iter().map(|d| d.to_json()).collect::<Errors>());
+    // let mut compiler = Compiler::new(); //.token_limit(...).recursion_limit(...) TODO!
+    let schema = Schema::parse(&create_schema(), "schema");
+    let document = ExecutableDocument::parse(&schema, &body.query, "query");
+
+    schema.validate().unwrap();
+
+    if let Err(diagnostics) = document.validate(&schema) {
+        return GraphQLReturn::from(diagnostics.iter().map(|d| d.to_json()).collect::<Errors>());
     }
-    let exec_operation: Arc<Operation> = match get_executing_operation(&compiler.db, body.operationName, query_key) {
-        Ok(op) => op,
-        Err(ret) => return ret
-    };
 
-    execute_operation(exec_operation, &compiler.db)
-}
-
-fn get_executing_operation(db: &impl HirDatabase, operation_name: Option<String>, db_key: FileId) -> Result<Arc<Operation>, GraphQLReturn> {
-    let operations: Arc<Vec<Arc<Operation>>> = db.all_operations();
-    match operations.len() {
-        0 => Err(GraphQLReturn::from("document does not contain any executable operations")),
-        1 => Ok(operations[0].clone()),
-        _ => {
-            if operation_name.is_none() {
-                return Err(GraphQLReturn::from("document contains more than one operation, missing operation name"));
-            }
-            let name: &str = &operation_name.unwrap();
-            match db.find_operation(db_key, Some(name.to_string())) {
-                Some(o) => Ok(o),
-                None => Err(GraphQLReturn::from(format!("operation with name {} does not exist", name).as_str()))
-            }
-        }
+    match get_executing_operation(&document, body.operationName) {
+        Ok(op) => execute_operation(op),
+        Err(ret) => ret
     }
 }
 
-fn execute_operation(operation: Arc<Operation>, db: &impl HirDatabase) -> GraphQLReturn {
-    let mut data = Data::new();
-    let mut errors = Errors::new();
-    for root_resolver in operation.selection_set().selection() {
-        let field: &Arc<Field> = match root_resolver {
-            Selection::Field(field) => field,
-            Selection::FragmentSpread(_) => todo!(),
-            Selection::InlineFragment(_) => todo!()
-        };
-        if field.is_introspection() {
-            match field.name() {
-                "__schema" => {
-                    let record = &mut Data::from(vec![
-                        (FieldName::from("types"), resolve_type_system(db)),
-                        (FieldName::from("queryType"), FieldValue::Object(resolve_type_definition(&db.find_type_definition_by_name("Query".to_string()).unwrap(), db).unwrap())),
-                        (FieldName::from("mutationType"), FieldValue::Object(resolve_type_definition(&db.find_type_definition_by_name("Mutation".to_string()).unwrap(), db).unwrap())),
-                        // (FieldName::from("subscriptionType"), FieldValue::Object(resolve_type_definition(&db.find_type_definition_by_name("Subscription".to_string()).unwrap(), db).unwrap())),
-                        (FieldName::from("subscriptionType"), FieldValue::Scalar(NULL)),
-                        (FieldName::from("directives"), FieldValue::Scalar(TrueType::Array(vec!().into()))) // directives currently not supported, so ther are none
-                    ]);
-                    data.insert(FieldName::from(field.response_name()), FieldValue::Object(resolve_selection_set_order(field.selection_set(), &field.ty(db).unwrap(), record, db)));
-                },
-                "__type" => match &db.find_type_definition_by_name(field.arguments()[0].value().as_str().unwrap().to_string()) {
-                    Some(def) => match resolve_type_definition(def, db) {
-                        Some(mut res) => data.insert(FieldName::from(field.name()), FieldValue::Object(resolve_selection_set_order(field.selection_set(), &field.ty(db).unwrap(), &mut res, db))),
-                        None => data.insert(FieldName::from(field.name()), FieldValue::Scalar(NULL))
-                    },
-                    None => data.insert(FieldName::from(field.name()), FieldValue::Scalar(NULL))
-                },
-                "__typename" => data.insert(FieldName::from(field.name()), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(format!("{}", operation.operation_ty())))))),
-                _ => unreachable!("as of GraphQL documentation are there only __type, __typename and __schema as introspection fields")
-            }
-            continue;
-        }
-        let resolver_name: &str = field.name();
-        let prefix: &str = match operation.operation_ty() {
-            OperationType::Query => {
-                if resolver_name.starts_with("readOne") {
-                    "readOne"
-                } else {
-                    ""  // readMany has no prefix because it's the plural variant of the model name
-                }
-            },
-            OperationType::Mutation => {
-                if resolver_name.starts_with("addOne") {
-                    "addOne"
-                } else if resolver_name.starts_with("updateOne") {
-                    "updateOne"
-                } else {
-                    "deleteOne" // operation is expected to be validated by handle_gql_post
-                }
-            },
-            OperationType::Subscription => todo!(),
-        };
+fn get_executing_operation(document: &ExecutableDocument, operation_name: Option<String>) -> Result<&Node<Operation>, GraphQLReturn> {
+    let mut operations /* impl Iterator<Item = OperationRef<'_>> */ = document.all_operations();
 
-        let args: HashMap<&str, TrueType> = HashMap::from_iter(
-            field.arguments().iter().map(|arg| (arg.name(), value_to_truetype(arg.value())) )
-        );
-
-        let record: Result<Record, std::io::Error> = match prefix {
-            "addOne" => create_one(resolver_name.strip_prefix(prefix).unwrap(), serde_json::to_string(&args).unwrap().as_str()),
-            "readOne" => {
-                let model_name: &str = resolver_name.strip_prefix(prefix).unwrap();
-                let id: &str = &args.values().next().unwrap().to_string();
-                read_one(model_name, id)
-            },
-            "updateOne" => {
-                let id_attr_name: &str = field.arguments()[0].name();
-                update_one(resolver_name.strip_prefix(prefix).unwrap(), &args.get(id_attr_name).unwrap().to_string(), serde_json::to_string(&args).unwrap().as_str())
-            },
-            "deleteOne" => {
-                let model_name: &str = resolver_name.strip_prefix(prefix).unwrap();
-                let id: &str = &args.values().next().unwrap().to_string();
-                delete_one(model_name, id)
-            },
-            "" => todo!(),
-            _ => unreachable!("there are currently only five root resolver types")
-        };
-
-        match record {
-            Ok(record) => {
-                let mut fields = Data::new();
-                for (attr_name, value) in record {
-                    fields.insert(attr_name.0, FieldValue::Scalar(value));
-                }
-                data.insert(FieldName::from(field.response_name()), FieldValue::Object(resolve_selection_set_order(field.selection_set(), &field.ty(db).unwrap(), &mut fields, db)));
-            },
-            Err(err) => errors.append(&mut vec!(GraphQLError {
-                message: format!("{}", err),
-                locations: vec!()
-            }))
-        }
+    if operations.next().is_none() {
+        return Err(GraphQLReturn::from("document does not contain any executable operations"));
+    }
+    if operation_name.is_none() && operations.next().is_some() {
+        return Err(GraphQLReturn::from("document contains more than one operation, missing operation name"));
     }
 
-    if errors.is_empty() {
-        return GraphQLReturn::from(data);
-    } else if data.is_empty() {
-        return GraphQLReturn::from(errors);
-    }
-
-    GraphQLReturn {
-        errors: Some(errors),
-        data: Some(data)
+    match document.get_operation(operation_name.as_deref()) {
+        Ok(o) => Ok(o.definition()),
+        Err(err) => Err(GraphQLReturn::from(format!("operation with name {:?} does not exist", operation_name.unwrap().as_str()).as_str()))
     }
 }
 
-fn value_to_truetype(value: &Value) -> TrueType {
-    match value {
-        Value::Variable(_) => todo!("resolve variable"),
-        Value::String { value, .. } => TrueType::Primitive(Some(TruePrimitiveType::String(value.clone()))),
-        Value::Boolean { value, .. } => TrueType::Primitive(Some(TruePrimitiveType::Boolean(*value))),
-        Value::Null { .. } => NULL,
-        Value::List { value, .. } => TrueType::Array(value.iter()
-                                                          .map(|val| {
-                                                              if let TrueType::Primitive(Some(v)) = value_to_truetype(val) {
-                                                                  return v;
-                                                              }
-                                                              unreachable!("arrays store TruePrimitiveType items")
-                                                          })
-                                                          .collect::<Vec<TruePrimitiveType>>().into()),
-        Value::Int { value, .. } => TrueType::Primitive(Some(TruePrimitiveType::Integer(value.to_i32_checked().expect("GraphQL integers are i32") as i64))),
-        _ => todo!()
-    }
+fn execute_operation(operation: &Node<Operation>) -> GraphQLReturn {
+    todo!()
 }
+//     let mut data = Data::new();
+//     let mut errors = Errors::new();
+//     for root_resolver in operation.selection_set().selection() {
+//         let field: &Arc<Field> = match root_resolver {
+//             Selection::Field(field) => field,
+//             Selection::FragmentSpread(_) => todo!(),
+//             Selection::InlineFragment(_) => todo!()
+//         };
+//         if field.is_introspection() {
+//             match field.name() {
+//                 "__schema" => {
+//                     let record = &mut Data::from(vec![
+//                         (FieldName::from("types"), resolve_type_system(db)),
+//                         (FieldName::from("queryType"), FieldValue::Object(resolve_type_definition(&db.find_type_definition_by_name("Query".to_string()).unwrap(), db).unwrap())),
+//                         (FieldName::from("mutationType"), FieldValue::Object(resolve_type_definition(&db.find_type_definition_by_name("Mutation".to_string()).unwrap(), db).unwrap())),
+//                         // (FieldName::from("subscriptionType"), FieldValue::Object(resolve_type_definition(&db.find_type_definition_by_name("Subscription".to_string()).unwrap(), db).unwrap())),
+//                         (FieldName::from("subscriptionType"), FieldValue::Scalar(NULL)),
+//                         (FieldName::from("directives"), FieldValue::Scalar(TrueType::Array(vec!().into()))) // directives currently not supported, so ther are none
+//                     ]);
+//                     data.insert(FieldName::from(field.response_name()), FieldValue::Object(resolve_selection_set_order(field.selection_set(), &field.ty(db).unwrap(), record, db)));
+//                 },
+//                 "__type" => match &db.find_type_definition_by_name(field.arguments()[0].value().as_str().unwrap().to_string()) {
+//                     Some(def) => match resolve_type_definition(def, db) {
+//                         Some(mut res) => data.insert(FieldName::from(field.name()), FieldValue::Object(resolve_selection_set_order(field.selection_set(), &field.ty(db).unwrap(), &mut res, db))),
+//                         None => data.insert(FieldName::from(field.name()), FieldValue::Scalar(NULL))
+//                     },
+//                     None => data.insert(FieldName::from(field.name()), FieldValue::Scalar(NULL))
+//                 },
+//                 "__typename" => data.insert(FieldName::from(field.name()), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(format!("{}", operation.operation_ty())))))),
+//                 _ => unreachable!("as of GraphQL documentation are there only __type, __typename and __schema as introspection fields")
+//             }
+//             continue;
+//         }
+//         let resolver_name: &str = field.name();
+//         let prefix: &str = match operation.operation_ty() {
+//             OperationType::Query => {
+//                 if resolver_name.starts_with("readOne") {
+//                     "readOne"
+//                 } else {
+//                     ""  // readMany has no prefix because it's the plural variant of the model name
+//                 }
+//             },
+//             OperationType::Mutation => {
+//                 if resolver_name.starts_with("addOne") {
+//                     "addOne"
+//                 } else if resolver_name.starts_with("updateOne") {
+//                     "updateOne"
+//                 } else {
+//                     "deleteOne" // operation is expected to be validated by handle_gql_post
+//                 }
+//             },
+//             OperationType::Subscription => todo!(),
+//         };
 
-fn resolve_selection_set_order(selection_set: &SelectionSet, resolver_ty: &Type,  field_data: &mut Data, db: &impl HirDatabase) -> Data {
-    let mut data = Data::new();
-    for sel in selection_set.selection() {
-        match sel {
-            Selection::Field(sel_field) => {
-                match field_data.get(&FieldName::from(sel_field.name())) {
-                    Some(FieldValue::Objects(mut sub_data)) => {
-                        let resolved: Vec<Data> = sub_data.iter_mut().map(|d| resolve_selection_set_order(sel_field.selection_set(), &sel_field.ty(db).unwrap(), d, db)).collect();
-                        data.insert(FieldName::from(sel_field.name()), FieldValue::Objects(resolved));
-                    },
-                    Some(FieldValue::Object(mut sub_data)) => {
-                        let resolved: Data = resolve_selection_set_order(sel_field.selection_set(), &sel_field.ty(db).unwrap(), &mut sub_data, db);
-                        data.insert(FieldName::from(sel_field.name()), FieldValue::Object(resolved));
-                    },
-                    Some(scalar) => data.insert(FieldName::from(sel_field.response_name()), scalar),
-                    None => {
-                        assert_eq!(sel_field.name(), "__typename", "Unhandled field \"{}\" in graphql request", sel_field.name());
-                        data.insert(FieldName::from(sel_field.name()), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(resolver_ty.name().to_string())))));
-                    }
-                }
-            },
-            Selection::FragmentSpread(frag) => data.append(resolve_selection_set_order(frag.fragment(db).unwrap().selection_set(), resolver_ty, field_data, db)),
-            Selection::InlineFragment(frag) => data.append(resolve_selection_set_order(frag.selection_set(), resolver_ty, field_data, db))
-        }
-    }
+//         let args: HashMap<&str, TrueType> = HashMap::from_iter(
+//             field.arguments().iter().map(|arg| (arg.name(), value_to_truetype(arg.value())) )
+//         );
 
-    data
-}
+//         let record: Result<Record, std::io::Error> = match prefix {
+//             "addOne" => create_one(resolver_name.strip_prefix(prefix).unwrap(), serde_json::to_string(&args).unwrap().as_str()),
+//             "readOne" => {
+//                 let model_name: &str = resolver_name.strip_prefix(prefix).unwrap();
+//                 let id: &str = &args.values().next().unwrap().to_string();
+//                 read_one(model_name, id)
+//             },
+//             "updateOne" => {
+//                 let id_attr_name: &str = field.arguments()[0].name();
+//                 update_one(resolver_name.strip_prefix(prefix).unwrap(), &args.get(id_attr_name).unwrap().to_string(), serde_json::to_string(&args).unwrap().as_str())
+//             },
+//             "deleteOne" => {
+//                 let model_name: &str = resolver_name.strip_prefix(prefix).unwrap();
+//                 let id: &str = &args.values().next().unwrap().to_string();
+//                 delete_one(model_name, id)
+//             },
+//             "" => todo!(),
+//             _ => unreachable!("there are currently only five root resolver types")
+//         };
 
-fn resolve_type_system(db: &impl HirDatabase) -> FieldValue {
-    let mut types: Vec<Data> = vec!();
-    for ty_def in db.type_system().type_definitions_by_name.values() {
-        if let Some(res) = resolve_type_definition(ty_def, db) {
-            types.push(res);
-        }
-    }
+//         match record {
+//             Ok(record) => {
+//                 let mut fields = Data::new();
+//                 for (attr_name, value) in record {
+//                     fields.insert(attr_name.0, FieldValue::Scalar(value));
+//                 }
+//                 data.insert(FieldName::from(field.response_name()), FieldValue::Object(resolve_selection_set_order(field.selection_set(), &field.ty(db).unwrap(), &mut fields, db)));
+//             },
+//             Err(err) => errors.append(&mut vec!(GraphQLError {
+//                 message: format!("{}", err),
+//                 locations: vec!()
+//             }))
+//         }
+//     }
 
-    FieldValue::Objects(types)
-}
+//     if errors.is_empty() {
+//         return GraphQLReturn::from(data);
+//     } else if data.is_empty() {
+//         return GraphQLReturn::from(errors);
+//     }
 
-fn resolve_type_definition(ty_def: &TypeDefinition, db: &impl HirDatabase) -> Option<Data> {
-    let mut data = Data::new();
-    data.insert(FieldName::from("name"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(ty_def.name().to_string())))));
+//     GraphQLReturn {
+//         errors: Some(errors),
+//         data: Some(data)
+//     }
+// }
 
-    match ty_def {
-        TypeDefinition::ObjectTypeDefinition(def) => {
-            data.insert(FieldName::from("kind"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String("OBJECT".to_string())))));
-            if def.is_introspection() {
-                return None; // don't resolve unnecessarily introspection types, and also avoid stack overflow
-            }
-            match def.description() {
-                Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
-                None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
-            }
-            let fields: Vec<Data> = def.fields().map(|f| resolve_field_definition(f, db)).collect();
-            data.insert(FieldName::from("fields"), FieldValue::Objects(fields));
-        },
-        TypeDefinition::ScalarTypeDefinition(def) => {
-            data.insert(FieldName::from("kind"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String("SCALAR".to_string())))));
-            match def.description() {
-                Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
-                None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
-            }
-            data.insert(FieldName::from("fields"), FieldValue::Scalar(NULL));
-        },
-        _ => return None
-    }
+// fn value_to_truetype(value: &Value) -> TrueType {
+//     match value {
+//         Value::Variable(_) => todo!("resolve variable"),
+//         Value::String { value, .. } => TrueType::Primitive(Some(TruePrimitiveType::String(value.clone()))),
+//         Value::Boolean { value, .. } => TrueType::Primitive(Some(TruePrimitiveType::Boolean(*value))),
+//         Value::Null { .. } => NULL,
+//         Value::List { value, .. } => TrueType::Array(value.iter()
+//                                                           .map(|val| {
+//                                                               if let TrueType::Primitive(Some(v)) = value_to_truetype(val) {
+//                                                                   return v;
+//                                                               }
+//                                                               unreachable!("arrays store TruePrimitiveType items")
+//                                                           })
+//                                                           .collect::<Vec<TruePrimitiveType>>().into()),
+//         Value::Int { value, .. } => TrueType::Primitive(Some(TruePrimitiveType::Integer(value.to_i32_checked().expect("GraphQL integers are i32") as i64))),
+//         _ => todo!()
+//     }
+// }
 
-    data.insert(FieldName::from("ofType"), FieldValue::Scalar(NULL)); // a type has no ofType if it has a TypeDefinition
+// fn resolve_selection_set_order(selection_set: &SelectionSet, resolver_ty: &Type,  field_data: &mut Data, db: &impl HirDatabase) -> Data {
+//     let mut data = Data::new();
+//     for sel in selection_set.selection() {
+//         match sel {
+//             Selection::Field(sel_field) => {
+//                 match field_data.get(&FieldName::from(sel_field.name())) {
+//                     Some(FieldValue::Objects(mut sub_data)) => {
+//                         let resolved: Vec<Data> = sub_data.iter_mut().map(|d| resolve_selection_set_order(sel_field.selection_set(), &sel_field.ty(db).unwrap(), d, db)).collect();
+//                         data.insert(FieldName::from(sel_field.name()), FieldValue::Objects(resolved));
+//                     },
+//                     Some(FieldValue::Object(mut sub_data)) => {
+//                         let resolved: Data = resolve_selection_set_order(sel_field.selection_set(), &sel_field.ty(db).unwrap(), &mut sub_data, db);
+//                         data.insert(FieldName::from(sel_field.name()), FieldValue::Object(resolved));
+//                     },
+//                     Some(scalar) => data.insert(FieldName::from(sel_field.response_name()), scalar),
+//                     None => {
+//                         assert_eq!(sel_field.name(), "__typename", "Unhandled field \"{}\" in graphql request", sel_field.name());
+//                         data.insert(FieldName::from(sel_field.name()), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(resolver_ty.name().to_string())))));
+//                     }
+//                 }
+//             },
+//             Selection::FragmentSpread(frag) => data.append(resolve_selection_set_order(frag.fragment(db).unwrap().selection_set(), resolver_ty, field_data, db)),
+//             Selection::InlineFragment(frag) => data.append(resolve_selection_set_order(frag.selection_set(), resolver_ty, field_data, db))
+//         }
+//     }
 
-    // the following fields get default values because they are currently not used
-    data.insert(FieldName::from("interfaces"), FieldValue::Scalar(TrueType::Array(vec!().into())));
-    data.insert(FieldName::from("enumValues"), FieldValue::Scalar(TrueType::Array(vec!().into()))); // because it affects enums, not used
-    data.insert(FieldName::from("possibleTypes"), FieldValue::Scalar(TrueType::Array(vec!().into()))); // because it affects interfaces
-    data.insert(FieldName::from("inputFields"), FieldValue::Scalar(TrueType::Array(vec!().into()))); // because it affects input types, not used
+//     data
+// }
 
-    Some(data)
-}
+// fn resolve_type_system(db: &impl HirDatabase) -> FieldValue {
+//     let mut types: Vec<Data> = vec!();
+//     for ty_def in db.type_system().type_definitions_by_name.values() {
+//         if let Some(res) = resolve_type_definition(ty_def, db) {
+//             types.push(res);
+//         }
+//     }
 
-fn resolve_type(ty: &Type, db: &impl HirDatabase) -> FieldValue {
-    if ty.is_named() {
-        return match resolve_type_definition(&ty.type_def(db).unwrap(), db) {
-            Some(res) => FieldValue::Object(res),
-            None => FieldValue::Scalar(NULL)
-        }
-    }
-    let mut resolved = Data::from(vec![
-        (FieldName::from("name"), FieldValue::Scalar(NULL)),
-        (FieldName::from("description"), FieldValue::Scalar(NULL)),
-        (FieldName::from("fields"), FieldValue::Scalar(TrueType::Array(vec!().into()))),
-        (FieldName::from("interfaces"), FieldValue::Scalar(TrueType::Array(vec!().into()))),
-        (FieldName::from("possibleTypes"), FieldValue::Scalar(TrueType::Array(vec!().into()))),
-        (FieldName::from("enumValues"), FieldValue::Scalar(TrueType::Array(vec!().into()))),
-        (FieldName::from("inputFields"), FieldValue::Scalar(TrueType::Array(vec!().into())))
-    ]);
-    let of_type: &Type = match ty {
-        Type::NonNull { ty, .. } => {
-            resolved.insert(FieldName::from("kind"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String("NON_NULL".to_string())))));
-            ty
-        },
-        Type::List { ty, .. } => {
-            resolved.insert(FieldName::from("kind"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String("LIST".to_string())))));
-            ty
-        },
-        Type::Named { .. } => unreachable!("handled at the beginning of this function")
-    };
-    resolved.insert(FieldName::from("ofType"), resolve_type(of_type, db));
+//     FieldValue::Objects(types)
+// }
 
-    FieldValue::Object(resolved)
-}
+// fn resolve_type_definition(ty_def: &TypeDefinition, db: &impl HirDatabase) -> Option<Data> {
+//     let mut data = Data::new();
+//     data.insert(FieldName::from("name"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(ty_def.name().to_string())))));
 
-fn resolve_field_definition(field: &FieldDefinition, db: &impl HirDatabase) -> Data {  // __Field
-    let mut data = Data::new();
-    data.insert(FieldName::from("name"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(field.name().to_string())))));
-    match field.description() {
-        Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
-        None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
-    }
+//     match ty_def {
+//         TypeDefinition::ObjectTypeDefinition(def) => {
+//             data.insert(FieldName::from("kind"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String("OBJECT".to_string())))));
+//             if def.is_introspection() {
+//                 return None; // don't resolve unnecessarily introspection types, and also avoid stack overflow
+//             }
+//             match def.description() {
+//                 Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
+//                 None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
+//             }
+//             let fields: Vec<Data> = def.fields().map(|f| resolve_field_definition(f, db)).collect();
+//             data.insert(FieldName::from("fields"), FieldValue::Objects(fields));
+//         },
+//         TypeDefinition::ScalarTypeDefinition(def) => {
+//             data.insert(FieldName::from("kind"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String("SCALAR".to_string())))));
+//             match def.description() {
+//                 Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
+//                 None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
+//             }
+//             data.insert(FieldName::from("fields"), FieldValue::Scalar(NULL));
+//         },
+//         _ => return None
+//     }
 
-    let args: Vec<Data> = field.arguments().input_values().iter().map(|a| {
-        let mut data = Data::from(vec![
-            (FieldName::from("name"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(a.name().to_string()))))),
-            (FieldName::from("type"), resolve_type(a.ty(), db))
-        ]);
-        match a.description() {
-            Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
-            None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
-        }
-        match a.default_value() {
-            Some(desc) => data.insert(FieldName::from("defaultValue"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(value_to_truetype(desc).to_string()))))),
-            None => data.insert(FieldName::from("defaultValue"), FieldValue::Scalar(NULL))
-        }
-        data
-    }).collect();
+//     data.insert(FieldName::from("ofType"), FieldValue::Scalar(NULL)); // a type has no ofType if it has a TypeDefinition
 
-    data.insert(FieldName::from("args"), FieldValue::Objects(args));
+//     // the following fields get default values because they are currently not used
+//     data.insert(FieldName::from("interfaces"), FieldValue::Scalar(TrueType::Array(vec!().into())));
+//     data.insert(FieldName::from("enumValues"), FieldValue::Scalar(TrueType::Array(vec!().into()))); // because it affects enums, not used
+//     data.insert(FieldName::from("possibleTypes"), FieldValue::Scalar(TrueType::Array(vec!().into()))); // because it affects interfaces
+//     data.insert(FieldName::from("inputFields"), FieldValue::Scalar(TrueType::Array(vec!().into()))); // because it affects input types, not used
 
-    data.insert(FieldName::from("type"), resolve_type(field.ty(), db));
-    data.insert(FieldName::from("isDeprecated"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::Boolean(false)))));
-    data.insert(FieldName::from("deprecationReason"), FieldValue::Scalar(NULL));
+//     Some(data)
+// }
 
-    data
-}
+// fn resolve_type(ty: &Type, db: &impl HirDatabase) -> FieldValue {
+//     if ty.is_named() {
+//         return match resolve_type_definition(&ty.type_def(db).unwrap(), db) {
+//             Some(res) => FieldValue::Object(res),
+//             None => FieldValue::Scalar(NULL)
+//         }
+//     }
+//     let mut resolved = Data::from(vec![
+//         (FieldName::from("name"), FieldValue::Scalar(NULL)),
+//         (FieldName::from("description"), FieldValue::Scalar(NULL)),
+//         (FieldName::from("fields"), FieldValue::Scalar(TrueType::Array(vec!().into()))),
+//         (FieldName::from("interfaces"), FieldValue::Scalar(TrueType::Array(vec!().into()))),
+//         (FieldName::from("possibleTypes"), FieldValue::Scalar(TrueType::Array(vec!().into()))),
+//         (FieldName::from("enumValues"), FieldValue::Scalar(TrueType::Array(vec!().into()))),
+//         (FieldName::from("inputFields"), FieldValue::Scalar(TrueType::Array(vec!().into())))
+//     ]);
+//     let of_type: &Type = match ty {
+//         Type::NonNull { ty, .. } => {
+//             resolved.insert(FieldName::from("kind"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String("NON_NULL".to_string())))));
+//             ty
+//         },
+//         Type::List { ty, .. } => {
+//             resolved.insert(FieldName::from("kind"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String("LIST".to_string())))));
+//             ty
+//         },
+//         Type::Named { .. } => unreachable!("handled at the beginning of this function")
+//     };
+//     resolved.insert(FieldName::from("ofType"), resolve_type(of_type, db));
+
+//     FieldValue::Object(resolved)
+// }
+
+// fn resolve_field_definition(field: &FieldDefinition, db: &impl HirDatabase) -> Data {  // __Field
+//     let mut data = Data::new();
+//     data.insert(FieldName::from("name"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(field.name().to_string())))));
+//     match field.description() {
+//         Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
+//         None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
+//     }
+
+//     let args: Vec<Data> = field.arguments().input_values().iter().map(|a| {
+//         let mut data = Data::from(vec![
+//             (FieldName::from("name"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(a.name().to_string()))))),
+//             (FieldName::from("type"), resolve_type(a.ty(), db))
+//         ]);
+//         match a.description() {
+//             Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
+//             None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
+//         }
+//         match a.default_value() {
+//             Some(desc) => data.insert(FieldName::from("defaultValue"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(value_to_truetype(desc).to_string()))))),
+//             None => data.insert(FieldName::from("defaultValue"), FieldValue::Scalar(NULL))
+//         }
+//         data
+//     }).collect();
+
+//     data.insert(FieldName::from("args"), FieldValue::Objects(args));
+
+//     data.insert(FieldName::from("type"), resolve_type(field.ty(), db));
+//     data.insert(FieldName::from("isDeprecated"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::Boolean(false)))));
+//     data.insert(FieldName::from("deprecationReason"), FieldValue::Scalar(NULL));
+
+//     data
+// }

--- a/src/cli/server/model/graphql.rs
+++ b/src/cli/server/model/graphql.rs
@@ -23,6 +23,7 @@ use apollo_compiler::{
     ExecutableDocument,
     GraphQLError,
     // HirDatabase,
+    NodeStr,
     Schema,
     // FileId,
     Node
@@ -36,8 +37,11 @@ use apollo_compiler::executable::{
     Field,
     Value,
     // FieldDefinition,
-    // TypeDefinition,
     Type
+};
+use apollo_compiler::schema::{
+    FieldDefinition,
+    ExtendedType
 };
 
 // used functions
@@ -265,17 +269,17 @@ fn to_gql_type(prim_type: &PrimitiveType) -> String {
 
 pub fn handle_gql_post(body: GraphQLPost) -> GraphQLReturn {
     // let mut compiler = Compiler::new(); //.token_limit(...).recursion_limit(...) TODO!
-    let schema = Schema::parse(create_schema(), "schema");
-    let document = ExecutableDocument::parse(&schema, &body.query, "query");
+    let schema = &Schema::parse(create_schema(), "schema");
+    let document = ExecutableDocument::parse(schema, &body.query, "query");
 
     schema.validate().unwrap();
 
-    if let Err(diagnostics) = document.validate(&schema) {
+    if let Err(diagnostics) = document.validate(schema) {
         return GraphQLReturn::from(diagnostics.iter().map(|d| d.to_json()).collect::<Errors>());
     }
 
     match get_executing_operation(&document, body.operationName) {
-        Ok(op) => execute_operation(op),
+        Ok(op) => execute_operation(op, schema),
         Err(ret) => ret
     }
 }
@@ -296,7 +300,7 @@ fn get_executing_operation(document: &ExecutableDocument, operation_name: Option
     }
 }
 
-fn execute_operation(operation: &Node<Operation>) -> GraphQLReturn {
+fn execute_operation(operation: &Node<Operation>, schema: &Schema) -> GraphQLReturn {
     let mut data = Data::new();
     let mut errors = Errors::new();
     for root_resolver in &operation.selection_set.selections {
@@ -305,94 +309,90 @@ fn execute_operation(operation: &Node<Operation>) -> GraphQLReturn {
             Selection::FragmentSpread(_) => todo!(),
             Selection::InlineFragment(_) => todo!()
         };
-        // if field.is_introspection() {
-        //     match field.name.as_str() {
-        //         "__schema" => {
-        //             let record = &mut Data::from(vec![
-        //                 (FieldName::from("types"), resolve_type_system(db)),
-        //                 (FieldName::from("queryType"), FieldValue::Object(resolve_type_definition(&db.find_type_definition_by_name("Query".to_string()).unwrap(), db).unwrap())),
-        //                 (FieldName::from("mutationType"), FieldValue::Object(resolve_type_definition(&db.find_type_definition_by_name("Mutation".to_string()).unwrap(), db).unwrap())),
-        //                 // (FieldName::from("subscriptionType"), FieldValue::Object(resolve_type_definition(&db.find_type_definition_by_name("Subscription".to_string()).unwrap(), db).unwrap())),
-        //                 (FieldName::from("subscriptionType"), FieldValue::Scalar(NULL)),
-        //                 (FieldName::from("directives"), FieldValue::Scalar(TrueType::Array(vec!().into()))) // directives currently not supported, so ther are none
-        //             ]);
-        //             data.insert(FieldName::from(field.response_name()), FieldValue::Object(resolve_selection_set_order(field.selection_set(), &field.ty(db).unwrap(), record, db)));
-        //         },
-        //         "__type" => match &db.find_type_definition_by_name(field.arguments()[0].value().as_str().unwrap().to_string()) {
-        //             Some(def) => match resolve_type_definition(def, db) {
-        //                 Some(mut res) => data.insert(FieldName::from(field.name.as_str()), FieldValue::Object(resolve_selection_set_order(field.selection_set(), &field.ty(db).unwrap(), &mut res, db))),
-        //                 None => data.insert(FieldName::from(field.name.as_str()), FieldValue::Scalar(NULL))
-        //             },
-        //             None => data.insert(FieldName::from(field.name.as_str()), FieldValue::Scalar(NULL))
-        //         },
-                // "__typename" => data.insert(FieldName::from(field.name.as_str()), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(operation.operation_type.to_string()))))),
-        //         _ => unreachable!("as of GraphQL documentation are there only __type, __typename and __schema as introspection fields")
-        //     }
-        //     continue;
-        // }
-        let resolver_name: &str = field.name.as_str();
-        let prefix: &str = match operation.operation_type {
-            OperationType::Query => {
-                if resolver_name.starts_with("readOne") {
-                    "readOne"
-                } else {
-                    ""  // readMany has no prefix because it's the plural variant of the model name
-                }
+        
+        match field.name.as_str() {
+            // "__schema" => {
+            //     let record = &mut Data::from(vec![
+            //         (FieldName::from("types"), resolve_type_system(db)),
+            //         (FieldName::from("queryType"), FieldValue::Object(resolve_type_definition(&db.find_type_definition_by_name("Query".to_string()).unwrap(), db).unwrap())),
+            //         (FieldName::from("mutationType"), FieldValue::Object(resolve_type_definition(&db.find_type_definition_by_name("Mutation".to_string()).unwrap(), db).unwrap())),
+            //         // (FieldName::from("subscriptionType"), FieldValue::Object(resolve_type_definition(&db.find_type_definition_by_name("Subscription".to_string()).unwrap(), db).unwrap())),
+            //         (FieldName::from("subscriptionType"), FieldValue::Scalar(NULL)),
+            //         (FieldName::from("directives"), FieldValue::Scalar(TrueType::Array(Some(vec!()))) // directives currently not supported, so ther are none
+            //     ]);
+            //     data.insert(FieldName::from(field.response_name()), FieldValue::Object(resolve_selection_set_order(&field.selection_set, &field.ty(), record)));
+            // },
+            "__type" => match resolve_type_definition(&NodeStr::new(field.arguments[0].value.as_str().unwrap()), schema) {
+                Some(mut res) => data.insert(FieldName::from(field.name.as_str()), FieldValue::Object(resolve_selection_set_order(&field.selection_set, &field.ty(), &mut res))),
+                None => data.insert(FieldName::from(field.name.as_str()), FieldValue::Scalar(NULL))
             },
-            OperationType::Mutation => {
-                if resolver_name.starts_with("addOne") {
-                    "addOne"
-                } else if resolver_name.starts_with("updateOne") {
-                    "updateOne"
-                } else {
-                    "deleteOne" // operation is expected to be validated by handle_gql_post
-                }
-            },
-            OperationType::Subscription => todo!(),
-        };
+            "__typename" => data.insert(FieldName::from(field.name.as_str()), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(operation.operation_type.to_string()))))),
 
-        let args: HashMap<&str, TrueType> = HashMap::from_iter(
-            field.arguments.iter().map(|arg| {
-                if let Some(arr) = arg.value.as_list() {
-                    (arg.name.as_str(), TrueType::Array(Some(arr.iter().map(|a| from_str::<TruePrimitiveType>(&a.to_string()).unwrap()).collect::<Vec<TruePrimitiveType>>())))
-                } else {
-                    (arg.name.as_str(), from_str::<TrueType>(&arg.value.to_string()).unwrap())
-                }
-            })
-        );
+            resolver_name => {
+                let prefix: &str = match operation.operation_type {
+                    OperationType::Query => {
+                        if resolver_name.starts_with("readOne") {
+                            "readOne"
+                        } else {
+                            ""  // readMany has no prefix because it's the plural variant of the model name
+                        }
+                    },
+                    OperationType::Mutation => {
+                        if resolver_name.starts_with("addOne") {
+                            "addOne"
+                        } else if resolver_name.starts_with("updateOne") {
+                            "updateOne"
+                        } else {
+                            "deleteOne" // operation is expected to be validated by handle_gql_post
+                        }
+                    },
+                    OperationType::Subscription => todo!(),
+                };
 
-        let record: Result<Record, std::io::Error> = match prefix {
-            "addOne" => create_one(resolver_name.strip_prefix(prefix).unwrap(), serde_json::to_string(&args).unwrap().as_str()),
-            "readOne" => {
-                let model_name: &str = resolver_name.strip_prefix(prefix).unwrap();
-                let id: &str = &args.values().next().unwrap().to_string();
-                read_one(model_name, id)
-            },
-            "updateOne" => {
-                let id_attr_name: &str = field.arguments[0].name.as_str();
-                update_one(resolver_name.strip_prefix(prefix).unwrap(), &args.get(id_attr_name).unwrap().to_string(), serde_json::to_string(&args).unwrap().as_str())
-            },
-            "deleteOne" => {
-                let model_name: &str = resolver_name.strip_prefix(prefix).unwrap();
-                let id: &str = &args.values().next().unwrap().to_string();
-                delete_one(model_name, id)
-            },
-            "" => todo!(),
-            _ => unreachable!("there are currently only five root resolver types")
-        };
+                let args: HashMap<&str, TrueType> = HashMap::from_iter(
+                    field.arguments.iter().map(|arg| {
+                        if let Some(arr) = arg.value.as_list() {
+                            (arg.name.as_str(), TrueType::Array(Some(arr.iter().map(|a| from_str::<TruePrimitiveType>(&a.to_string()).unwrap()).collect::<Vec<TruePrimitiveType>>())))
+                        } else {
+                            (arg.name.as_str(), from_str::<TrueType>(&arg.value.to_string()).unwrap())
+                        }
+                    })
+                );
 
-        match record {
-            Ok(record) => {
-                let mut fields = Data::new();
-                for (attr_name, value) in record {
-                    fields.insert(attr_name.0, FieldValue::Scalar(value));
+                let record: Result<Record, std::io::Error> = match prefix {
+                    "addOne" => create_one(resolver_name.strip_prefix(prefix).unwrap(), serde_json::to_string(&args).unwrap().as_str()),
+                    "readOne" => {
+                        let model_name: &str = resolver_name.strip_prefix(prefix).unwrap();
+                        let id: &str = &args.values().next().unwrap().to_string();
+                        read_one(model_name, id)
+                    },
+                    "updateOne" => {
+                        let id_attr_name: &str = field.arguments[0].name.as_str();
+                        update_one(resolver_name.strip_prefix(prefix).unwrap(), &args.get(id_attr_name).unwrap().to_string(), serde_json::to_string(&args).unwrap().as_str())
+                    },
+                    "deleteOne" => {
+                        let model_name: &str = resolver_name.strip_prefix(prefix).unwrap();
+                        let id: &str = &args.values().next().unwrap().to_string();
+                        delete_one(model_name, id)
+                    },
+                    "" => todo!(),
+                    _ => unreachable!("there are currently only five root resolver types")
+                };
+
+                match record {
+                    Ok(record) => {
+                        let mut fields = Data::new();
+                        for (attr_name, value) in record {
+                            fields.insert(attr_name.0, FieldValue::Scalar(value));
+                        }
+                        data.insert(FieldName::from(field.response_key().as_str()), FieldValue::Object(resolve_selection_set_order(&field.selection_set, field.ty(), &mut fields)));
+                    },
+                    Err(err) => errors.append(&mut vec!(GraphQLError {
+                        message: format!("{}", err),
+                        locations: vec!()
+                    }))
                 }
-                data.insert(FieldName::from(field.response_key().as_str()), FieldValue::Object(resolve_selection_set_order(&field.selection_set, field.ty(), &mut fields)));
-            },
-            Err(err) => errors.append(&mut vec!(GraphQLError {
-                message: format!("{}", err),
-                locations: vec!()
-            }))
+            }
         }
     }
 
@@ -449,46 +449,50 @@ fn resolve_selection_set_order(selection_set: &SelectionSet, resolver_ty: &Type,
 //     FieldValue::Objects(types)
 // }
 
-// fn resolve_type_definition(ty_def: &TypeDefinition, db: &impl HirDatabase) -> Option<Data> {
-//     let mut data = Data::new();
-//     data.insert(FieldName::from("name"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(ty_def.name().to_string())))));
+fn resolve_type_definition(ty_name: &NodeStr, schema: &Schema) -> Option<Data> {
+    let mut data = Data::new();
 
-//     match ty_def {
-//         TypeDefinition::ObjectTypeDefinition(def) => {
-//             data.insert(FieldName::from("kind"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String("OBJECT".to_string())))));
-//             if def.is_introspection() {
-//                 return None; // don't resolve unnecessarily introspection types, and also avoid stack overflow
-//             }
-//             match def.description() {
-//                 Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
-//                 None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
-//             }
-//             let fields: Vec<Data> = def.fields().map(|f| resolve_field_definition(f, db)).collect();
-//             data.insert(FieldName::from("fields"), FieldValue::Objects(fields));
-//         },
-//         TypeDefinition::ScalarTypeDefinition(def) => {
-//             data.insert(FieldName::from("kind"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String("SCALAR".to_string())))));
-//             match def.description() {
-//                 Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
-//                 None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
-//             }
-//             data.insert(FieldName::from("fields"), FieldValue::Scalar(NULL));
-//         },
-//         _ => return None
-//     }
+    let ty_def: &ExtendedType = schema.types.get(ty_name)?;
+    
+    data.insert(FieldName::from("name"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(ty_name.to_string())))));
 
-//     data.insert(FieldName::from("ofType"), FieldValue::Scalar(NULL)); // a type has no ofType if it has a TypeDefinition
+    match ty_def {
+        ExtendedType::Object(def) => {
+            data.insert(FieldName::from("kind"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String("OBJECT".to_string())))));
+            // if def.is_introspection() {
+            //     return None; // don't resolve unnecessarily introspection types, and also avoid stack overflow
+            // }
+            match &def.description {
+                Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
+                None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
+            }
+            let fields: Vec<Data> = def.fields.values().map(|f| resolve_field_definition(&f.node, schema)).collect();
+            data.insert(FieldName::from("fields"), FieldValue::Objects(fields));
+        },
+        ExtendedType::Scalar(def) => {
+            data.insert(FieldName::from("kind"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String("SCALAR".to_string())))));
+            match &def.description {
+                Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
+                None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
+            }
+            data.insert(FieldName::from("fields"), FieldValue::Scalar(NULL));
+        },
+        _ => return None
+    }
 
-//     // the following fields get default values because they are currently not used
-//     data.insert(FieldName::from("interfaces"), FieldValue::Scalar(TrueType::Array(vec!().into())));
-//     data.insert(FieldName::from("enumValues"), FieldValue::Scalar(TrueType::Array(vec!().into()))); // because it affects enums, not used
-//     data.insert(FieldName::from("possibleTypes"), FieldValue::Scalar(TrueType::Array(vec!().into()))); // because it affects interfaces
-//     data.insert(FieldName::from("inputFields"), FieldValue::Scalar(TrueType::Array(vec!().into()))); // because it affects input types, not used
+    data.insert(FieldName::from("ofType"), FieldValue::Scalar(NULL)); // a type has no ofType if it has a TypeDefinition
 
-//     Some(data)
-// }
+    // the following fields get default values because they are currently not used
+    data.insert(FieldName::from("interfaces"), FieldValue::Scalar(TrueType::Array(Some(vec!()))));
+    data.insert(FieldName::from("enumValues"), FieldValue::Scalar(TrueType::Array(Some(vec!())))); // because it affects enums, not used
+    data.insert(FieldName::from("possibleTypes"), FieldValue::Scalar(TrueType::Array(Some(vec!())))); // because it affects interfaces
+    data.insert(FieldName::from("inputFields"), FieldValue::Scalar(TrueType::Array(Some(vec!())))); // because it affects input types, not used
 
-// fn resolve_type(ty: &Type, db: &impl HirDatabase) -> FieldValue {
+    Some(data)
+}
+
+fn resolve_type(ty: &Type, schema: &Schema) -> FieldValue {
+    todo!()}
 //     if ty.is_named() {
 //         return match resolve_type_definition(&ty.type_def(db).unwrap(), db) {
 //             Some(res) => FieldValue::Object(res),
@@ -498,11 +502,11 @@ fn resolve_selection_set_order(selection_set: &SelectionSet, resolver_ty: &Type,
 //     let mut resolved = Data::from(vec![
 //         (FieldName::from("name"), FieldValue::Scalar(NULL)),
 //         (FieldName::from("description"), FieldValue::Scalar(NULL)),
-//         (FieldName::from("fields"), FieldValue::Scalar(TrueType::Array(vec!().into()))),
-//         (FieldName::from("interfaces"), FieldValue::Scalar(TrueType::Array(vec!().into()))),
-//         (FieldName::from("possibleTypes"), FieldValue::Scalar(TrueType::Array(vec!().into()))),
-//         (FieldName::from("enumValues"), FieldValue::Scalar(TrueType::Array(vec!().into()))),
-//         (FieldName::from("inputFields"), FieldValue::Scalar(TrueType::Array(vec!().into())))
+//         (FieldName::from("fields"), FieldValue::Scalar(TrueType::Array(Some(vec!()))),
+//         (FieldName::from("interfaces"), FieldValue::Scalar(TrueType::Array(Some(vec!()))),
+//         (FieldName::from("possibleTypes"), FieldValue::Scalar(TrueType::Array(Some(vec!()))),
+//         (FieldName::from("enumValues"), FieldValue::Scalar(TrueType::Array(Some(vec!()))),
+//         (FieldName::from("inputFields"), FieldValue::Scalar(TrueType::Array(Some(vec!())))
 //     ]);
 //     let of_type: &Type = match ty {
 //         Type::NonNull { ty, .. } => {
@@ -520,35 +524,35 @@ fn resolve_selection_set_order(selection_set: &SelectionSet, resolver_ty: &Type,
 //     FieldValue::Object(resolved)
 // }
 
-// fn resolve_field_definition(field: &FieldDefinition, db: &impl HirDatabase) -> Data {  // __Field
-//     let mut data = Data::new();
-//     data.insert(FieldName::from("name"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(field.name().to_string())))));
-//     match field.description() {
-//         Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
-//         None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
-//     }
+fn resolve_field_definition(field: &Node<FieldDefinition>, schema: &Schema) -> Data {  // __Field
+    let mut data = Data::new();
+    data.insert(FieldName::from("name"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(field.name.to_string())))));
+    match &field.description {
+        Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
+        None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
+    }
 
-//     let args: Vec<Data> = field.arguments().input_values().iter().map(|a| {
-//         let mut data = Data::from(vec![
-//             (FieldName::from("name"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(a.name().to_string()))))),
-//             (FieldName::from("type"), resolve_type(a.ty(), db))
-//         ]);
-//         match a.description() {
-//             Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
-//             None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
-//         }
-//         match a.default_value() {
-//             Some(desc) => data.insert(FieldName::from("defaultValue"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(value_to_truetype(desc).to_string()))))),
-//             None => data.insert(FieldName::from("defaultValue"), FieldValue::Scalar(NULL))
-//         }
-//         data
-//     }).collect();
+    let args: Vec<Data> = field.arguments.iter().map(|a| {
+        let mut data = Data::from(vec![
+            (FieldName::from("name"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(a.name.to_string()))))),
+            (FieldName::from("type"), resolve_type(&a.ty, schema))
+        ]);
+        match &a.description {
+            Some(desc) => data.insert(FieldName::from("description"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(desc.to_string()))))),
+            None => data.insert(FieldName::from("description"), FieldValue::Scalar(NULL))
+        }
+        match &a.default_value {
+            Some(val) => data.insert(FieldName::from("defaultValue"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::String(val.to_string()))))),
+            None => data.insert(FieldName::from("defaultValue"), FieldValue::Scalar(NULL))
+        }
+        data
+    }).collect();
 
-//     data.insert(FieldName::from("args"), FieldValue::Objects(args));
+    data.insert(FieldName::from("args"), FieldValue::Objects(args));
 
-//     data.insert(FieldName::from("type"), resolve_type(field.ty(), db));
-//     data.insert(FieldName::from("isDeprecated"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::Boolean(false)))));
-//     data.insert(FieldName::from("deprecationReason"), FieldValue::Scalar(NULL));
+    data.insert(FieldName::from("type"), resolve_type(&field.ty, schema));
+    data.insert(FieldName::from("isDeprecated"), FieldValue::Scalar(TrueType::Primitive(Some(TruePrimitiveType::Boolean(false)))));
+    data.insert(FieldName::from("deprecationReason"), FieldValue::Scalar(NULL));
 
-//     data
-// }
+    data
+}


### PR DESCRIPTION
The `apollo-compiler` is a work in progress, so using the latest state of the crate
is a good preparation for the upcoming stable release if the compiler is ready
developed but also a good thing to help the compiler making the last steps to
a stable release. Since this repo is also a work in progress, it's not necessary to
keep the stable version `0.11.3`.

So this PR updates the graphql module to use the latest `apollo-compiler`.